### PR TITLE
Changed proxyContextEs5 name to proxylessContext, fixed addRuleSet bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Bug with environments that cannot use the Proxy object ([#45](https://github.com/imbrn/v8n/issues/45))
+
+### Fixed
+
 - Bug with schema validation ([#166](https://github.com/imbrn/v8n/pull/166))
 
 ## [1.3.3] - 2019-09-15

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -10,7 +10,7 @@ sidebar: auto
 
 - **Signature:** `v8n()`
 
-- **Returns:** `Proxy`
+- **Returns:** `Proxy` or `Object` in environments where `Proxy` is unavailable.
 
 - **Usage:**
 

--- a/src/v8n.js
+++ b/src/v8n.js
@@ -3,7 +3,7 @@ import Context from "./Context";
 function v8n() {
   return typeof Proxy !== "undefined"
     ? proxyContext(new Context())
-    : proxyContextEs5(new Context());
+    : proxylessContext(new Context());
 }
 
 // Custom rules
@@ -39,11 +39,11 @@ function proxyContext(context) {
   });
 }
 
-function proxyContextEs5(context) {
-  const addRuleSet = (ruleSet, targetContext) =>
+function proxylessContext(context) {
+  const addRuleSet = (ruleSet, targetContext) => {
     Object.keys(ruleSet).forEach(prop => {
       targetContext[prop] = (...args) => {
-        const newContext = proxyContextEs5(targetContext._clone());
+        const newContext = proxylessContext(targetContext._clone());
         const contextWithRuleApplied = newContext._applyRule(
           ruleSet[prop],
           prop
@@ -51,6 +51,8 @@ function proxyContextEs5(context) {
         return contextWithRuleApplied;
       };
     });
+    return targetContext;
+  };
 
   const contextWithAvailableRules = addRuleSet(availableRules, context);
   const contextWithAllRules = addRuleSet(
@@ -61,7 +63,7 @@ function proxyContextEs5(context) {
   Object.keys(availableModifiers).forEach(prop => {
     Object.defineProperty(contextWithAllRules, prop, {
       get: () => {
-        const newContext = proxyContextEs5(contextWithAllRules._clone());
+        const newContext = proxylessContext(contextWithAllRules._clone());
         return newContext._applyModifier(availableModifiers[prop], prop);
       }
     });


### PR DESCRIPTION
<!--- !!! PLEASE DELETE CONTENT THAT IS NOT RELEVANT !!! -->

## Description

Fixed `addRuleSet` method so that it returns the context object correctly.

Fixes bug in PR [#171](https://github.com/imbrn/v8n/pull/171) which fixes issue [#45](https://github.com/imbrn/v8n/issues/45).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please, feel free to specify what kind of change it is)

## Checklist:

- [x] I have created my branch from a recent version of `master`
- [x] The code is clean and easy to understand
- [x] I have written tests to guarantee that everything is working properly
  - I have, but out of scope for this project, since they needed to be in an environment without a `Proxy` object.
- [x] I have made corresponding changes to the documentation
- [x] I have added changes to the `Unreleased` section of the CHANGELOG
